### PR TITLE
Pushing of Settings V2 API Objects

### DIFF
--- a/docker/configmanager/configmanager.py
+++ b/docker/configmanager/configmanager.py
@@ -1056,7 +1056,10 @@ def getConfig(parameters):
     configtypes = [c for c in [getattr(ConfigTypes, cls.__name__) if len(
         cls.__subclasses__()) == 0 else None for cls in ConfigTypes.TenantConfigV1Entity.__subclasses__()] if c]
     configtypes = configtypes + [getattr(ConfigTypes, cls.__name__) for cls in ConfigTypes.TenantConfigV1Setting.__subclasses__()]
+    configtypes = configtypes + [c for c in [getattr(ConfigTypes, cls.__name__) if len(
+        cls.__subclasses__()) == 0 else None for cls in ConfigTypes.TenantEnvironmentV2Setting.__subclasses__()] if c]
     # getConfigSettings(configtypes, parameters, dumpconfig)
+
     return configtypes
 
 

--- a/docker/configmanager/configset/ConfigSet.py
+++ b/docker/configmanager/configset/ConfigSet.py
@@ -1,12 +1,13 @@
 import sys
+import traceback
 import logging
 import yaml
 
 from configtypes import ConfigTypes
 
 # LOG CONFIGURATION
-#FORMAT = '%(asctime)s:%(levelname)s: %(message)s'
-#logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=FORMAT)
+# FORMAT = '%(asctime)s:%(levelname)s: %(message)s'
+# logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=FORMAT)
 logger = logging.getLogger("ConfigSet")
 
 
@@ -29,14 +30,14 @@ class ConfigSet:
                 config = yaml.load(definition_file, Loader=yaml.Loader)
                 self.entities = self.load(config, "configtypes", None)
         except:
-            logger.error("Can't load definitions: {}".format(sys.exc_info()))
+            logger.error("Can't load definitions: {}".format(traceback.format_exc()))
 
     def load(self, config, pscope, cscope):
         entities = []
         logger.info("Load: %s.%s", pscope, cscope if cscope else "")
         for k, v in config.items():
             if isinstance(v, dict):
-                #entities = entities + self.load(v, k, pscope)
+                # entities = entities + self.load(v, k, pscope)
                 entities = entities + self.load(v, ".".join([s for s in [pscope, cscope if cscope else None] if s]), k)
             else:
                 if isinstance(v, list):
@@ -48,7 +49,7 @@ class ConfigSet:
                             configEntity = class_(basedir=self.configbasedir, **entity)
                         except:
                             logger.error("Couldn't create config entity {}, please check config definitions!".format(pscope+k))
-                        #configEntity = class_(basedir=self.configbasedir,id=entity["id"],name=entity["name"])
+                        # configEntity = class_(basedir=self.configbasedir,id=entity["id"],name=entity["name"])
                         entities.append(configEntity)
 
         return entities

--- a/docker/configmanager/configtypes/ConfigTypes.py
+++ b/docker/configmanager/configtypes/ConfigTypes.py
@@ -208,6 +208,8 @@ In API V2 settings are part of the environment API, while in V1 they were part o
 
 
 class TenantEnvironmentV2Setting(TenantEnvironmentV2Entity):
+    uri = "/e/TENANTID/api/v2/settings"
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.id = self.__class__.__name__
@@ -216,10 +218,13 @@ class TenantEnvironmentV2Setting(TenantEnvironmentV2Entity):
         self.file = kwargs.get("file", self.__class__.__name__)
 
     def __str__(self):
-        return f'{self.__class__.__base__.__name__}: {type(self).__name__}'
+        return f'{self.__class__.__base__.__name__}: {type(self).__name__} [schema: {self.dto[0]["schemaId"]}] [externalId: {self.dto[0]["externalId"]}]'
 
     def __repr__(self):
-        return f'{self.__class__.__base__.__name__}: {type(self).__name__}'
+        return f'{self.__class__.__base__.__name__}: {type(self).__name__} [schema: {self.dto[0]["schemaId"]}] [externalId: {self.dto[0]["externalId"]}]'
+
+    def getHttpMethod(self):
+        return "POST"
 
 
 class ClusterConfigEntity(ConfigEntity):

--- a/docker/configmanager/configtypes/env_v2/settings/__init__.py
+++ b/docker/configmanager/configtypes/env_v2/settings/__init__.py
@@ -1,1 +1,1 @@
-from .dummySetting import *
+from .object import *

--- a/docker/configmanager/configtypes/env_v2/settings/object.py
+++ b/docker/configmanager/configtypes/env_v2/settings/object.py
@@ -1,8 +1,8 @@
 from ...ConfigTypes import TenantEnvironmentV2Setting
 
 
-class dummySetting(TenantEnvironmentV2Setting):
-    entityuri = "/dummy"
+class object(TenantEnvironmentV2Setting):
+    entityuri = "/objects"
     uri = TenantEnvironmentV2Setting.uri + entityuri
 
     def __init__(self, **kwargs):

--- a/docker/test/push_command.json
+++ b/docker/test/push_command.json
@@ -6,11 +6,13 @@
         "dryrun": false
     },
     "config": {
-        "config_v1.autoTags": true,
-        "config_v1.applicationsweb": true,
+        "config_v1.autoTags": false,
+        "config_v1.applicationsweb": false,
         "config_v1.applicationswebdataPrivacy": true,
-        "config_v1.applicationsweberrorRules": true,
-        "config_v1.applicationswebkeyUserActions": true,
-        "config_v1.servicerequestAttributes": true
+        "config_v1.applicationsweberrorRules": false,
+        "config_v1.applicationswebkeyUserActions": false,
+        "config_v1.servicerequestAttributes": false,
+        "config_v1.setting.anomalyDetectionservices": true,
+        "env_v2.settings.object": true
     }
 }


### PR DESCRIPTION
One can now create settings V2 definitions and push them via configmanager (pull not yet implemented).